### PR TITLE
CONVOCORE: user snippet, modalMode full-screen, convocore-fullscreen.…

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,34 +23,36 @@
     <meta name="twitter:title" content="RecklessBear | Premium Custom Sportswear">
     <meta name="twitter:description" content="RecklessBear designs and manufactures elite custom sportswear for schools, teams, and athletes in South Africa. From concept to creation — Do it Reckless.">
     <meta name="twitter:image" content="https://res.cloudinary.com/dnlgohkcc/image/upload/v1768799688/reckless_logo_r910n4.png">
-
-    <link rel="preconnect" href="https://vg-bunny-cdn.b-cdn.net">
-    <script>
-      window.VG_CONFIG = {
-        ID: "6BhLW2avFF69X0ydpkZ3",
-        region: "na",
-        render: "bottom-right",
-        stylesheets: ["https://vg-bunny-cdn.b-cdn.net/vg_live_build/styles.css"]
-      };
-    </script>
   </head>
   <body class="bg-black">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
 
-    <div id="VG_OVERLAY_CONTAINER" style="position: relative; z-index: 99999; overflow: visible;">
+    <div style="width: 0; height: 0;" id="VG_OVERLAY_CONTAINER">
         <!-- Here is where CONVOCORE renders the widget. -->
+        <!-- Set render to 'full-width' then adjust the width and height to 500px (for example) to render the chatbot itself without the popup. -->
     </div>
 
-    <script>
+    <!-- Remove 'defer' if you want widget to load faster (Will affect website loading) -->
+    <script defer>
         (function() {
-            if (!document.querySelector('script[src*="vg_bundle.js"]')) {
-                var VG_SCRIPT = document.createElement("script");
-                VG_SCRIPT.src = "https://vg-bunny-cdn.b-cdn.net/vg_live_build/vg_bundle.js";
-                VG_SCRIPT.defer = false;
-                document.body.appendChild(VG_SCRIPT);
+            window.VG_CONFIG = {
+                ID: "6BhLW2avFF69X0ydpkZ3", // YOUR AGENT ID
+                region: 'na', // YOUR ACCOUNT REGION 
+                render: 'bottom-right', // can be 'full-width' or 'bottom-left' or 'bottom-right'
+                modalMode: true, // Set this to 'true' to open the widget in modal mode
+                stylesheets: [
+                    // Base CONVOCORE CSS
+                    "https://vg-bunny-cdn.b-cdn.net/vg_live_build/styles.css",
+                    // Full-screen modal + wider chat on desktop
+                    "/convocore-fullscreen.css",
+                ],
             }
-        })();
+            var VG_SCRIPT = document.createElement("script");
+            VG_SCRIPT.src = "https://vg-bunny-cdn.b-cdn.net/vg_live_build/vg_bundle.js";
+            VG_SCRIPT.defer = true; // Remove 'defer' if you want widget to load faster (Will affect website loading)
+            document.body.appendChild(VG_SCRIPT);
+        })()
     </script>
   </body>
 </html>

--- a/public/convocore-fullscreen.css
+++ b/public/convocore-fullscreen.css
@@ -29,3 +29,19 @@
   max-height: 100% !important;
   border-radius: 0 !important;
 }
+
+/* On desktop: make the open chat panel a bit wider (520px); overlay stays full-screen */
+@media (min-width: 768px) {
+  #vg-widget-container,
+  #VG_OVERLAY_CONTAINER .vg-panel,
+  #VG_OVERLAY_CONTAINER .vg-widget-modal,
+  #VG_OVERLAY_CONTAINER [class*="panel"] {
+    width: 520px !important;
+    max-width: 90vw !important;
+    min-width: 420px !important;
+    height: 90vh !important;
+    max-height: 90vh !important;
+    margin: auto !important;
+    border-radius: 12px !important;
+  }
+}


### PR DESCRIPTION
…css, 520px desktop

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates the CONVOCORE chat widget with modal full-screen behavior and desktop sizing tweaks.
> 
> - Replaces legacy snippet with `window.VG_CONFIG` (modalMode enabled, `render: 'bottom-right'`) and loads `vg_bundle.js` with `defer`
> - Adds `public/convocore-fullscreen.css` to force full-screen overlay and set a wider desktop chat panel (~520px, 90vh)
> - Adjusts `#VG_OVERLAY_CONTAINER` sizing and includes stylesheet hook in `index.html`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b7598df01550c44adccd841ec29699888cbe5e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->