### PR TITLE
CONVOCORE: modalMode false, drop fullscreen CSS for tiny bottom-right…

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,12 +40,9 @@
                 ID: "6BhLW2avFF69X0ydpkZ3", // YOUR AGENT ID
                 region: 'na', // YOUR ACCOUNT REGION 
                 render: 'bottom-right', // can be 'full-width' or 'bottom-left' or 'bottom-right'
-                modalMode: true, // Set this to 'true' to open the widget in modal mode
+                modalMode: false, // false = small corner panel; true = full-screen modal
                 stylesheets: [
-                    // Base CONVOCORE CSS
                     "https://vg-bunny-cdn.b-cdn.net/vg_live_build/styles.css",
-                    // Full-screen modal + wider chat on desktop
-                    "/convocore-fullscreen.css",
                 ],
             }
             var VG_SCRIPT = document.createElement("script");


### PR DESCRIPTION
… widget

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates CONVOCORE embed configuration for a smaller in-page widget.
> 
> - Set `modalMode` to `false` to render the bottom-right panel instead of the full-screen modal
> - Remove `'/convocore-fullscreen.css'` from `stylesheets`, keeping only base `styles.css`
> - Minor comment cleanup in `index.html`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 201f7d9d65e231214da3b56e1ab4f2c9c127b911. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->