### PR TITLE
CONVOCORE: bottom-right bubble, 0x0 container, defer false for visibi…

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,26 +28,23 @@
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
 
-    <div style="width: 500px; height: 500px;" id="VG_OVERLAY_CONTAINER">
+    <div style="width: 0; height: 0;" id="VG_OVERLAY_CONTAINER">
     <!-- Here is where CONVOCORE renders the widget. -->
-    <!-- Set width, height for 500px as an example after changing render to 'full-width' -->
     </div>
 
-    <!-- Remove 'defer' if you want widget to load faster (Will affect website loading) -->
-    <script defer>
+    <script>
         (function() {
             window.VG_CONFIG = {
                 ID: "6BhLW2avFF69X0ydpkZ3",
-                region: 'na', // 'eu' or 'na'corresponding to Europe and North America
-                render: 'full-width', // popup or full-width
-                // modalMode: true, // Set this to 'true' to open the widget in modal mode
+                region: 'na',
+                render: 'bottom-right', // floating bubble, always visible
                 stylesheets: [
                     "https://vg-bunny-cdn.b-cdn.net/vg_live_build/styles.css",
                 ],
             }
             var VG_SCRIPT = document.createElement("script");
             VG_SCRIPT.src = "https://vg-bunny-cdn.b-cdn.net/vg_live_build/vg_bundle.js";
-            VG_SCRIPT.defer = true; // Remove 'defer' if you want widget to load faster (Will affect website loading)
+            VG_SCRIPT.defer = false; // load sooner so bubble appears
             document.body.appendChild(VG_SCRIPT);
         })()
     </script>


### PR DESCRIPTION
…lity

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts the CONVOCORE widget to a floating bubble and loads it earlier for visibility.
> 
> - Change `VG_CONFIG.render` from `full-width` to `bottom-right`
> - Set `#VG_OVERLAY_CONTAINER` size to `0x0` to avoid layout impact
> - Remove `defer` on the loader script and set `VG_SCRIPT.defer = false` to load sooner
> - Keep `region: 'na'` and include existing stylesheet config
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60ca4951d61faabfd0de82d6ffb24098fc6f2415. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->