### PR TITLE
fix: add _headers and netlify.toml to fix JS/CSS MIME type (applicati…

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  publish = "dist"

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,7 @@
+# Ensure .js and .css are served with correct MIME so module scripts load
+# (fixes: "Expected a JavaScript module but got application/octet-stream")
+/assets/*.js
+  Content-Type: application/javascript; charset=UTF-8
+
+/assets/*.css
+  Content-Type: text/css; charset=UTF-8


### PR DESCRIPTION
…on/octet-stream)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures deployed assets are served with correct MIME types so module scripts load correctly.
> 
> - Adds `netlify.toml` with `[build] publish = "dist"`
> - Introduces `public/_headers` to set `Content-Type` for `/assets/*.js` (`application/javascript; charset=UTF-8`) and `/assets/*.css` (`text/css; charset=UTF-8`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 786c7e83c33aca3dfb98f9fcebc732cec44bd856. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->