### PR TITLE
feat: add new Convocore chatbot (agent 6BhLW2avFF69X0ydpkZ3) in ifram…

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,9 +23,83 @@
     <meta name="twitter:title" content="RecklessBear | Premium Custom Sportswear">
     <meta name="twitter:description" content="RecklessBear designs and manufactures elite custom sportswear for schools, teams, and athletes in South Africa. From concept to creation — Do it Reckless.">
     <meta name="twitter:image" content="https://res.cloudinary.com/dnlgohkcc/image/upload/v1768799688/reckless_logo_r910n4.png">
+    
+    <!-- The chatbot styles have been restored -->
+    <style>
+      /* Mobile-specific styles for the chatbot widget */
+      @media (max-width: 768px) {
+        #vg-widget-container {
+          transform: scale(0.85);
+          transform-origin: bottom right;
+          margin: 0 !important;
+          right: -15px !important;
+          bottom: -15px !important;
+        }
+        .vg-bubble-button {
+          padding: 12px !important;
+        }
+        .vg-bubble-button svg {
+          width: 24px !important;
+          height: 24px !important;
+        }
+        .vg-widget {
+          max-width: 320px !important;
+        }
+        .vg-messages-container {
+          font-size: 14px !important;
+        }
+        .vg-input-container {
+          padding: 8px !important;
+        }
+      }
+      /* New chatbot iframe – bottom-left, un-inverted; hidden on quote/form via ContactForm */
+      #chatbot-iframe-new {
+        position: fixed;
+        bottom: 16px;
+        left: 16px;
+        width: 400px;
+        height: 560px;
+        border: none;
+        z-index: 99998;
+        border-radius: 12px;
+        box-shadow: 0 4px 24px rgba(0,0,0,0.3);
+      }
+      @media (max-width: 768px) {
+        #chatbot-iframe-new {
+          width: 340px;
+          height: 480px;
+          bottom: 12px;
+          left: 12px;
+        }
+      }
+    </style>
   </head>
   <body class="bg-black">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+
+    <!-- The chatbot script and its container have been restored -->
+    <div style="width: 0; height: 0;" id="VG_OVERLAY_CONTAINER">
+    </div>
+
+    <script>
+        (function() {
+            window.VG_CONFIG = {
+                ID: "8qQvlIvdBrn1cdle8sFD", // YOUR AGENT ID
+                region: 'na', // YOUR ACCOUNT REGION 
+                render: 'bottom-right', // can be 'full-width' or 'bottom-left' or 'bottom-right'
+                stylesheets: [
+                    "https://vg-bunny-cdn.b-cdn.net/vg_live_build/styles.css",
+                ],
+            }
+            var VG_SCRIPT = document.createElement("script");
+            VG_SCRIPT.src = "https://vg-bunny-cdn.b-cdn.net/vg_live_build/vg_bundle.js";
+            VG_SCRIPT.defer = true;
+            document.body.appendChild(VG_SCRIPT);
+        })()
+    </script>
+
+    <!-- New chatbot (un-inverted), bottom-left – agent 6BhLW2avFF69X0ydpkZ3 -->
+    <iframe id="chatbot-iframe-new" src="/widget-new.html" title="Chat"></iframe>
   </body>
 </html>

--- a/public/widget-new.html
+++ b/public/widget-new.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chat</title>
+  <style>
+    /* New chatbot: flip so text and layout are NOT inverted (LTR) */
+    #VG_OVERLAY_CONTAINER.convocore-uninvert,
+    #VG_OVERLAY_CONTAINER.convocore-uninvert .vg-widget,
+    #VG_OVERLAY_CONTAINER.convocore-uninvert .vg-messages-container,
+    #VG_OVERLAY_CONTAINER.convocore-uninvert .vg-input-container,
+    #VG_OVERLAY_CONTAINER.convocore-uninvert .vg-bubble-button { direction: ltr !important; }
+    /* If visually mirrored, uncomment: #VG_OVERLAY_CONTAINER.convocore-uninvert { transform: scaleX(-1); } */
+    body { margin: 0; background: transparent; min-height: 100vh; }
+  </style>
+</head>
+<body>
+  <div id="VG_OVERLAY_CONTAINER" class="convocore-uninvert"></div>
+  <script>
+    (function(){
+      window.VG_CONFIG = {
+        ID: "6BhLW2avFF69X0ydpkZ3",
+        region: 'na',
+        render: 'bottom-right',
+        modalMode: false,
+        stylesheets: [
+          "https://vg-bunny-cdn.b-cdn.net/vg_live_build/styles.css",
+          "/convocore-overrides.css"
+        ]
+      };
+      var s = document.createElement("script");
+      s.src = "https://vg-bunny-cdn.b-cdn.net/vg_live_build/vg_bundle.js";
+      s.defer = true;
+      document.body.appendChild(s);
+    })();
+  </script>
+</body>
+</html>

--- a/src/components/ui/ContactForm.tsx
+++ b/src/components/ui/ContactForm.tsx
@@ -70,9 +70,10 @@ const ContactForm: React.FC = () => {
 
   // Load Tally embed script when quote or form view is active
   useEffect(() => {
-    // Hide chatbot widget when forms are active
+    // Hide chatbot widgets when forms are active
     const chatbotWidget = document.getElementById('vg-widget-container');
     const chatbotButton = document.querySelector('.vg-bubble-button');
+    const iframeNew = document.getElementById('chatbot-iframe-new');
     
     if (chatbotWidget) {
       if (activeView === 'quote' || activeView === 'form') {
@@ -88,6 +89,10 @@ const ContactForm: React.FC = () => {
       } else {
         (chatbotButton as HTMLElement).style.display = '';
       }
+    }
+    
+    if (iframeNew) {
+      (iframeNew as HTMLElement).style.display = (activeView === 'quote' || activeView === 'form') ? 'none' : '';
     }
     
     if (activeView === 'quote' || activeView === 'form') {
@@ -109,6 +114,8 @@ const ContactForm: React.FC = () => {
       if (chatbotButton) {
         (chatbotButton as HTMLElement).style.display = '';
       }
+      const el = document.getElementById('chatbot-iframe-new');
+      if (el) (el as HTMLElement).style.display = '';
     };
   }, [activeView]);
 


### PR DESCRIPTION
…e, un-inverted, bottom-left; hide both on quote/form

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a second chatbot and restores the original, with responsive styling and view-based visibility control.
> 
> - Adds `public/widget-new.html` to load Convocore agent `6BhLW2avFF69X0ydpkZ3` with LTR overrides and bundled styles
> - Updates `index.html` to restore VG widget (agent `8qQvlIvdBrn1cdle8sFD`), add mobile styles, and embed the new iframe `#chatbot-iframe-new` (bottom-left)
> - Updates `ContactForm.tsx` to hide both the VG widget and the new iframe when `activeView` is `quote` or `form`, with proper cleanup; also loads Tally embeds on those views
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98414368551c4a02a86071a601c658052cd45877. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->