### PR TITLE
chore: remove loading=lazy from all img and iframe to rule out lazy-l…

### DIFF
--- a/src/components/ui/ContactForm.tsx
+++ b/src/components/ui/ContactForm.tsx
@@ -206,9 +206,7 @@ const ContactForm: React.FC = () => {
             
             <div className="bg-rb-gray-900 rounded-xl overflow-hidden shadow-inner">
               <iframe 
-                data-tally-src={getQuoteFormUrl()}
-                loading="lazy"
-                width="100%" 
+                data-tally-src={getQuoteFormUrl()} width="100%" 
                 height="950" 
                 style={{ 
                   border: 'none', 
@@ -273,9 +271,7 @@ const ContactForm: React.FC = () => {
             
             <div className="bg-rb-gray-900 rounded-xl overflow-hidden shadow-inner">
               <iframe 
-                data-tally-src={getQuestionFormUrl()}
-                loading="lazy"
-                width="100%" 
+                data-tally-src={getQuestionFormUrl()} width="100%" 
                 height="700" 
                 style={{ 
                   border: 'none', 

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -245,9 +245,7 @@ const AboutPage: React.FC = () => {
                 width="100%" 
                 height="100%" 
                 style={{ border: 0 }} 
-                allowFullScreen 
-                loading="lazy" 
-                referrerPolicy="no-referrer-when-downgrade"
+                allowFullScreen referrerPolicy="no-referrer-when-downgrade"
               ></iframe>
             </div>
           </motion.div>

--- a/src/pages/products/AthleticsLadiesVestPage.tsx
+++ b/src/pages/products/AthleticsLadiesVestPage.tsx
@@ -68,9 +68,7 @@ const AthleticsLadiesVestPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const AthleticsLadiesVestPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/AthleticsLongTShirtPage.tsx
+++ b/src/pages/products/AthleticsLongTShirtPage.tsx
@@ -68,9 +68,7 @@ const AthleticsLongTShirtPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const AthleticsLongTShirtPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/AthleticsMensVestPage.tsx
+++ b/src/pages/products/AthleticsMensVestPage.tsx
@@ -68,9 +68,7 @@ const AthleticsMensVestPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const AthleticsMensVestPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/AthleticsShortTShirtPage.tsx
+++ b/src/pages/products/AthleticsShortTShirtPage.tsx
@@ -69,9 +69,7 @@ const AthleticsShortTShirtPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const AthleticsShortTShirtPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/AthleticsShortsPage.tsx
+++ b/src/pages/products/AthleticsShortsPage.tsx
@@ -68,9 +68,7 @@ const AthleticsShortsPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const AthleticsShortsPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/CorporatePufferLongPage.tsx
+++ b/src/pages/products/CorporatePufferLongPage.tsx
@@ -68,9 +68,7 @@ const CorporatePufferLongPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const CorporatePufferLongPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• Designed for all-day office comfort and movement</li>
-                  <li>• Soft-touch finish with a premium professional appearance</li>
-                  <li>• Durable, easy-care materials suitable for repeated washing</li>
-                  <li>• Modern fit tailored for corporate environments</li>
-                  <li>• Available in custom colors to match company branding</li>
+                  <li>â€¢ Designed for all-day office comfort and movement</li>
+                  <li>â€¢ Soft-touch finish with a premium professional appearance</li>
+                  <li>â€¢ Durable, easy-care materials suitable for repeated washing</li>
+                  <li>â€¢ Modern fit tailored for corporate environments</li>
+                  <li>â€¢ Available in custom colors to match company branding</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/CorporatePufferShortPage.tsx
+++ b/src/pages/products/CorporatePufferShortPage.tsx
@@ -68,9 +68,7 @@ const CorporatePufferShortPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const CorporatePufferShortPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• Designed for all-day office comfort and movement</li>
-                  <li>• Soft-touch finish with a premium professional appearance</li>
-                  <li>• Durable, easy-care materials suitable for repeated washing</li>
-                  <li>• Modern fit tailored for corporate environments</li>
-                  <li>• Available in custom colors to match company branding</li>
+                  <li>â€¢ Designed for all-day office comfort and movement</li>
+                  <li>â€¢ Soft-touch finish with a premium professional appearance</li>
+                  <li>â€¢ Durable, easy-care materials suitable for repeated washing</li>
+                  <li>â€¢ Modern fit tailored for corporate environments</li>
+                  <li>â€¢ Available in custom colors to match company branding</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/CorporateShirtPage.tsx
+++ b/src/pages/products/CorporateShirtPage.tsx
@@ -68,9 +68,7 @@ const CorporateShirtPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const CorporateShirtPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• Designed for all-day office comfort and movement</li>
-                  <li>• Soft-touch finish with a premium professional appearance</li>
-                  <li>• Durable, easy-care materials suitable for repeated washing</li>
-                  <li>• Modern fit tailored for corporate environments</li>
-                  <li>• Available in custom colors to match company branding</li>
+                  <li>â€¢ Designed for all-day office comfort and movement</li>
+                  <li>â€¢ Soft-touch finish with a premium professional appearance</li>
+                  <li>â€¢ Durable, easy-care materials suitable for repeated washing</li>
+                  <li>â€¢ Modern fit tailored for corporate environments</li>
+                  <li>â€¢ Available in custom colors to match company branding</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/CorporateSoftshellPage.tsx
+++ b/src/pages/products/CorporateSoftshellPage.tsx
@@ -68,9 +68,7 @@ const CorporateSoftshellPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const CorporateSoftshellPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• Designed for all-day office comfort and movement</li>
-                  <li>• Soft-touch finish with a premium professional appearance</li>
-                  <li>• Durable, easy-care materials suitable for repeated washing</li>
-                  <li>• Modern fit tailored for corporate environments</li>
-                  <li>• Available in custom colors to match company branding</li>
+                  <li>â€¢ Designed for all-day office comfort and movement</li>
+                  <li>â€¢ Soft-touch finish with a premium professional appearance</li>
+                  <li>â€¢ Durable, easy-care materials suitable for repeated washing</li>
+                  <li>â€¢ Modern fit tailored for corporate environments</li>
+                  <li>â€¢ Available in custom colors to match company branding</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/CorporateZipTopPage.tsx
+++ b/src/pages/products/CorporateZipTopPage.tsx
@@ -68,9 +68,7 @@ const CorporateZipTopPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const CorporateZipTopPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• Designed for all-day office comfort and movement</li>
-                  <li>• Soft-touch finish with a premium professional appearance</li>
-                  <li>• Durable, easy-care materials suitable for repeated washing</li>
-                  <li>• Modern fit tailored for corporate environments</li>
-                  <li>• Available in custom colors to match company branding</li>
+                  <li>â€¢ Designed for all-day office comfort and movement</li>
+                  <li>â€¢ Soft-touch finish with a premium professional appearance</li>
+                  <li>â€¢ Durable, easy-care materials suitable for repeated washing</li>
+                  <li>â€¢ Modern fit tailored for corporate environments</li>
+                  <li>â€¢ Available in custom colors to match company branding</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/CricketLongGolferPage.tsx
+++ b/src/pages/products/CricketLongGolferPage.tsx
@@ -68,9 +68,7 @@ const CricketLongGolferPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const CricketLongGolferPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/CricketPantsPage.tsx
+++ b/src/pages/products/CricketPantsPage.tsx
@@ -69,9 +69,7 @@ const CricketPantsPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const CricketPantsPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• Traditional cricket whites with modern performance</li>
-                  <li>• Breathable fabric for all-day comfort</li>
-                  <li>• Reinforced seams for durability during play</li>
-                  <li>• Classic fit with freedom of movement</li>
-                  <li>• Easy to clean and maintain match after match</li>
+                  <li>â€¢ Traditional cricket whites with modern performance</li>
+                  <li>â€¢ Breathable fabric for all-day comfort</li>
+                  <li>â€¢ Reinforced seams for durability during play</li>
+                  <li>â€¢ Classic fit with freedom of movement</li>
+                  <li>â€¢ Easy to clean and maintain match after match</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/CricketShirtPage.tsx
+++ b/src/pages/products/CricketShirtPage.tsx
@@ -69,9 +69,7 @@ const CricketShirtPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const CricketShirtPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for long cricket matches</li>
-                  <li>• UV protection and breathable fabric technology</li>
-                  <li>• Moisture-wicking properties for all-day comfort</li>
-                  <li>• Classic cricket styling with modern performance</li>
-                  <li>• Easy to clean and maintain match after match</li>
+                  <li>â€¢ High-performance design for long cricket matches</li>
+                  <li>â€¢ UV protection and breathable fabric technology</li>
+                  <li>â€¢ Moisture-wicking properties for all-day comfort</li>
+                  <li>â€¢ Classic cricket styling with modern performance</li>
+                  <li>â€¢ Easy to clean and maintain match after match</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/CyclingShirtPage.tsx
+++ b/src/pages/products/CyclingShirtPage.tsx
@@ -68,9 +68,7 @@ const CyclingShirtPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const CyclingShirtPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/FishingHoodiePage.tsx
+++ b/src/pages/products/FishingHoodiePage.tsx
@@ -68,9 +68,7 @@ const FishingHoodiePage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const FishingHoodiePage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/FishingTeeLongPage.tsx
+++ b/src/pages/products/FishingTeeLongPage.tsx
@@ -68,9 +68,7 @@ const FishingTeeLongPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const FishingTeeLongPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/FishingTeeShortPage.tsx
+++ b/src/pages/products/FishingTeeShortPage.tsx
@@ -69,9 +69,7 @@ const FishingTeeShortPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const FishingTeeShortPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/FishingZipTopPage.tsx
+++ b/src/pages/products/FishingZipTopPage.tsx
@@ -69,9 +69,7 @@ const FishingZipTopPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const FishingZipTopPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/GolfDressPage.tsx
+++ b/src/pages/products/GolfDressPage.tsx
@@ -69,9 +69,7 @@ const GolfDressPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const GolfDressPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/GolfShirtPage.tsx
+++ b/src/pages/products/GolfShirtPage.tsx
@@ -69,9 +69,7 @@ const GolfShirtPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const GolfShirtPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/GolfZipTopPage.tsx
+++ b/src/pages/products/GolfZipTopPage.tsx
@@ -69,9 +69,7 @@ const GolfZipTopPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const GolfZipTopPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/GymShirtPage.tsx
+++ b/src/pages/products/GymShirtPage.tsx
@@ -69,9 +69,7 @@ const GymShirtPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const GymShirtPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• Lightweight, moisture-wicking performance fabric</li>
-                  <li>• Four-way stretch for unrestricted movement</li>
-                  <li>• Reinforced stitching for intense workouts</li>
-                  <li>• Breathable and sweat-resistant</li>
-                  <li>• Premium feel, built for repeated washing</li>
+                  <li>â€¢ Lightweight, moisture-wicking performance fabric</li>
+                  <li>â€¢ Four-way stretch for unrestricted movement</li>
+                  <li>â€¢ Reinforced stitching for intense workouts</li>
+                  <li>â€¢ Breathable and sweat-resistant</li>
+                  <li>â€¢ Premium feel, built for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/GymVestPage.tsx
+++ b/src/pages/products/GymVestPage.tsx
@@ -68,9 +68,7 @@ const GymVestPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const GymVestPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• Lightweight, moisture-wicking performance fabric</li>
-                  <li>• Four-way stretch for unrestricted movement</li>
-                  <li>• Reinforced stitching for intense workouts</li>
-                  <li>• Breathable and sweat-resistant</li>
-                  <li>• Premium feel, built for repeated washing</li>
+                  <li>â€¢ Lightweight, moisture-wicking performance fabric</li>
+                  <li>â€¢ Four-way stretch for unrestricted movement</li>
+                  <li>â€¢ Reinforced stitching for intense workouts</li>
+                  <li>â€¢ Breathable and sweat-resistant</li>
+                  <li>â€¢ Premium feel, built for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/HockeyDressPage.tsx
+++ b/src/pages/products/HockeyDressPage.tsx
@@ -68,9 +68,7 @@ const HockeyDressPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const HockeyDressPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/HockeyLadiesVestPage.tsx
+++ b/src/pages/products/HockeyLadiesVestPage.tsx
@@ -68,9 +68,7 @@ const HockeyLadiesVestPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const HockeyLadiesVestPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/HockeyMensVestPage.tsx
+++ b/src/pages/products/HockeyMensVestPage.tsx
@@ -68,9 +68,7 @@ const HockeyMensVestPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const HockeyMensVestPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/HockeyShirtPage.tsx
+++ b/src/pages/products/HockeyShirtPage.tsx
@@ -69,9 +69,7 @@ const HockeyShirtPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const HockeyShirtPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense hockey matches</li>
-                  <li>• Advanced moisture-wicking technology</li>
-                  <li>• Lightweight construction for maximum speed</li>
-                  <li>• Reinforced areas for durability during play</li>
-                  <li>• Easy to clean and maintain</li>
+                  <li>â€¢ High-performance design for intense hockey matches</li>
+                  <li>â€¢ Advanced moisture-wicking technology</li>
+                  <li>â€¢ Lightweight construction for maximum speed</li>
+                  <li>â€¢ Reinforced areas for durability during play</li>
+                  <li>â€¢ Easy to clean and maintain</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/HockeyShortsPage.tsx
+++ b/src/pages/products/HockeyShortsPage.tsx
@@ -68,9 +68,7 @@ const HockeyShortsPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const HockeyShortsPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/HockeyTShirtLongPage.tsx
+++ b/src/pages/products/HockeyTShirtLongPage.tsx
@@ -68,9 +68,7 @@ const HockeyTShirtLongPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const HockeyTShirtLongPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/HockeyTShirtShortPage.tsx
+++ b/src/pages/products/HockeyTShirtShortPage.tsx
@@ -69,9 +69,7 @@ const HockeyTShirtShortPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const HockeyTShirtShortPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/HuntingHoodiePage.tsx
+++ b/src/pages/products/HuntingHoodiePage.tsx
@@ -68,9 +68,7 @@ const HuntingHoodiePage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const HuntingHoodiePage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/HuntingPufferLongPage.tsx
+++ b/src/pages/products/HuntingPufferLongPage.tsx
@@ -68,9 +68,7 @@ const HuntingPufferLongPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const HuntingPufferLongPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/HuntingPufferShortPage.tsx
+++ b/src/pages/products/HuntingPufferShortPage.tsx
@@ -68,9 +68,7 @@ const HuntingPufferShortPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const HuntingPufferShortPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/HuntingSoftshellPage.tsx
+++ b/src/pages/products/HuntingSoftshellPage.tsx
@@ -68,9 +68,7 @@ const HuntingSoftshellPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const HuntingSoftshellPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/HuntingZipTopPage.tsx
+++ b/src/pages/products/HuntingZipTopPage.tsx
@@ -69,9 +69,7 @@ const HuntingZipTopPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const HuntingZipTopPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/LeggingsPage.tsx
+++ b/src/pages/products/LeggingsPage.tsx
@@ -67,9 +67,7 @@ const LeggingsPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -117,11 +115,11 @@ const LeggingsPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• Lightweight, moisture-wicking performance fabric</li>
-                  <li>• Four-way stretch for unrestricted movement</li>
-                  <li>• Reinforced stitching for intense workouts</li>
-                  <li>• Breathable and sweat-resistant</li>
-                  <li>• Premium feel, built for repeated washing</li>
+                  <li>â€¢ Lightweight, moisture-wicking performance fabric</li>
+                  <li>â€¢ Four-way stretch for unrestricted movement</li>
+                  <li>â€¢ Reinforced stitching for intense workouts</li>
+                  <li>â€¢ Breathable and sweat-resistant</li>
+                  <li>â€¢ Premium feel, built for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/NetballDressPage.tsx
+++ b/src/pages/products/NetballDressPage.tsx
@@ -69,9 +69,7 @@ const NetballDressPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const NetballDressPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• Athletic cut designed for freedom of movement</li>
-                  <li>• Sweat-wicking and breathable fabric technology</li>
-                  <li>• Flattering fit that maintains shape during play</li>
-                  <li>• Premium feel with smooth, comfortable finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ Athletic cut designed for freedom of movement</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric technology</li>
+                  <li>â€¢ Flattering fit that maintains shape during play</li>
+                  <li>â€¢ Premium feel with smooth, comfortable finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/NetballHotPantsPage.tsx
+++ b/src/pages/products/NetballHotPantsPage.tsx
@@ -69,9 +69,7 @@ const NetballHotPantsPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const NetballHotPantsPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/NetballLadiesVestPage.tsx
+++ b/src/pages/products/NetballLadiesVestPage.tsx
@@ -68,9 +68,7 @@ const NetballLadiesVestPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const NetballLadiesVestPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/NetballShortsPage.tsx
+++ b/src/pages/products/NetballShortsPage.tsx
@@ -69,9 +69,7 @@ const NetballShortsPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const NetballShortsPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense netball matches</li>
-                  <li>• Sweat-wicking and breathable fabric technology</li>
-                  <li>• Flexible fit for unrestricted movement</li>
-                  <li>• Premium feel with smooth, comfortable finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense netball matches</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric technology</li>
+                  <li>â€¢ Flexible fit for unrestricted movement</li>
+                  <li>â€¢ Premium feel with smooth, comfortable finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/NetballSkortPage.tsx
+++ b/src/pages/products/NetballSkortPage.tsx
@@ -68,9 +68,7 @@ const NetballSkortPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const NetballSkortPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/RugbyJerseysPage.tsx
+++ b/src/pages/products/RugbyJerseysPage.tsx
@@ -69,9 +69,7 @@ const RugbyJerseysPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,12 +117,12 @@ const RugbyJerseysPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• Built for maximum mobility during high-intensity matches</li>
-                  <li>• Sweat-wicking finish keeps players cool and dry</li>
-                  <li>• Reinforced seams to handle the toughest tackles</li>
-                  <li>• Contoured fit for full range of motion</li>
-                  <li>• Easy to clean, designed for repeated wash & wear</li>
-                  <li>• Smooth finish for premium look on and off the field</li>
+                  <li>â€¢ Built for maximum mobility during high-intensity matches</li>
+                  <li>â€¢ Sweat-wicking finish keeps players cool and dry</li>
+                  <li>â€¢ Reinforced seams to handle the toughest tackles</li>
+                  <li>â€¢ Contoured fit for full range of motion</li>
+                  <li>â€¢ Easy to clean, designed for repeated wash & wear</li>
+                  <li>â€¢ Smooth finish for premium look on and off the field</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/RugbyShortsPage.tsx
+++ b/src/pages/products/RugbyShortsPage.tsx
@@ -69,9 +69,7 @@ const RugbyShortsPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const RugbyShortsPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/RugbyWarmupLongPage.tsx
+++ b/src/pages/products/RugbyWarmupLongPage.tsx
@@ -68,9 +68,7 @@ const RugbyWarmupLongPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -118,11 +116,11 @@ const RugbyWarmupLongPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/RugbyWarmupShortPage.tsx
+++ b/src/pages/products/RugbyWarmupShortPage.tsx
@@ -69,9 +69,7 @@ const RugbyWarmupShortPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const RugbyWarmupShortPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense rugby play</li>
-                  <li>• Sweat-wicking and breathable fabric for comfort</li>
-                  <li>• Reinforced seams to withstand tackles and scrums</li>
-                  <li>• Premium feel with smooth finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense rugby play</li>
+                  <li>â€¢ Sweat-wicking and breathable fabric for comfort</li>
+                  <li>â€¢ Reinforced seams to withstand tackles and scrums</li>
+                  <li>â€¢ Premium feel with smooth finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/SoccerJerseyPage.tsx
+++ b/src/pages/products/SoccerJerseyPage.tsx
@@ -69,9 +69,7 @@ const SoccerJerseyPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const SoccerJerseyPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• High-performance design for intense soccer matches</li>
-                  <li>• Advanced sweat-wicking and breathable fabric</li>
-                  <li>• Lightweight construction for maximum speed</li>
-                  <li>• Premium feel with smooth, aerodynamic finish</li>
-                  <li>• Easy to clean and made for repeated washing</li>
+                  <li>â€¢ High-performance design for intense soccer matches</li>
+                  <li>â€¢ Advanced sweat-wicking and breathable fabric</li>
+                  <li>â€¢ Lightweight construction for maximum speed</li>
+                  <li>â€¢ Premium feel with smooth, aerodynamic finish</li>
+                  <li>â€¢ Easy to clean and made for repeated washing</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/SoccerShortsPage.tsx
+++ b/src/pages/products/SoccerShortsPage.tsx
@@ -69,9 +69,7 @@ const SoccerShortsPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const SoccerShortsPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• Lightweight design for maximum speed and agility</li>
-                  <li>• Advanced moisture-wicking technology</li>
-                  <li>• Four-way stretch for unrestricted movement</li>
-                  <li>• Reinforced seams for durability during play</li>
-                  <li>• Easy to clean and quick-drying</li>
+                  <li>â€¢ Lightweight design for maximum speed and agility</li>
+                  <li>â€¢ Advanced moisture-wicking technology</li>
+                  <li>â€¢ Four-way stretch for unrestricted movement</li>
+                  <li>â€¢ Reinforced seams for durability during play</li>
+                  <li>â€¢ Easy to clean and quick-drying</li>
                 </ul>
               </motion.div>
 

--- a/src/pages/products/TracksuitsPage.tsx
+++ b/src/pages/products/TracksuitsPage.tsx
@@ -69,9 +69,7 @@ const TracksuitsPage: React.FC = () => {
                       <img 
                         src={image.src} 
                         alt={`Thumbnail ${index + 1}`} 
-                        className="w-full h-full object-cover" 
-                        loading="lazy" 
-                      />
+                        className="w-full h-full object-cover" />
                     </button>
                   ))}
                 </div>
@@ -119,11 +117,11 @@ const TracksuitsPage: React.FC = () => {
               >
                 <h3 className="text-xl font-bebas mb-4">FABRIC SPECIFICATIONS</h3>
                 <ul className="space-y-2 text-rb-gray-300">
-                  <li>• Complete tracksuit set for team coordination</li>
-                  <li>• Moisture-wicking fabric for training comfort</li>
-                  <li>• Durable construction for repeated wear</li>
-                  <li>• Professional appearance for team events</li>
-                  <li>• Easy care and machine washable</li>
+                  <li>â€¢ Complete tracksuit set for team coordination</li>
+                  <li>â€¢ Moisture-wicking fabric for training comfort</li>
+                  <li>â€¢ Durable construction for repeated wear</li>
+                  <li>â€¢ Professional appearance for team events</li>
+                  <li>â€¢ Easy care and machine washable</li>
                 </ul>
               </motion.div>
 


### PR DESCRIPTION
…oad blocking images

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Remove lazy-loading from media**: Strips `loading="lazy"` from `img` thumbnails and main images across many product pages, and from Tally/Google Maps `iframe` embeds in `ContactForm.tsx` and `AboutPage.tsx`.
> - **Iframe attribute cleanup**: Consolidates attributes (e.g., `data-tally-src` with `width`, `allowFullScreen` + `referrerPolicy`) without functional changes.
> - **Text content change**: Bullet characters in multiple "FABRIC SPECIFICATIONS" lists changed from `•` to `â€¢` (encoding regression) across many product pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44e4d9a30cde6bbdcd433937063ac7ee1819e78d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->