### PR TITLE
Add Convocore override stylesheet to hide proactive notifications and constrain widget/modal

### DIFF
--- a/public/convocore-overrides.css
+++ b/public/convocore-overrides.css
@@ -1,87 +1,64 @@
-/* Fix: CONVOCORE widget elements were stretching to viewport-sized
-   because of CSS conflicts. Completely hide proactive notification - it cannot be constrained. */
+/* Convocore overrides: hide proactive notifications, size bubble/modal, constrain tabs. */
 .vg-proactive-notification--container,
-div.vg-proactive-notification--container,
 [class*="proactive-notification"],
-[class*="proactive"],
-.vg-fixed.vg-bg-primary.vg-proactive-notification--container,
-div[class*="bg-primary"][class*="rounded"] {
+[class*="proactive"] {
   display: none !important;
   visibility: hidden !important;
   opacity: 0 !important;
+  pointer-events: none !important;
   width: 0 !important;
   height: 0 !important;
-  overflow: hidden !important;
-  pointer-events: none !important;
-  position: absolute !important;
-  left: -9999px !important;
   max-width: 0 !important;
   max-height: 0 !important;
+  overflow: hidden !important;
+  position: absolute !important;
+  left: -9999px !important;
 }
-/* Hide large red elements that might be the proactive notification */
-div[style*="background-color: rgb(255, 0, 0)"],
-div[style*="background-color:rgb(255,0,0)"],
-div[style*="background-color:#ff0000"],
-div[style*="background-color:#f00"] {
-  display: none !important;
-  visibility: hidden !important;
-  opacity: 0 !important;
-  width: 0 !important;
-  height: 0 !important;
-  pointer-events: none !important;
-}
-.vg-widget-controls-container {
-  width: auto !important;
-  min-width: unset !important;
-  max-width: 80px !important;
-  height: auto !important;
-  min-height: unset !important;
-  max-height: 80px !important;
-  position: fixed !important;
-  bottom: 20px !important;
-  right: 20px !important;
-  top: auto !important;
-  left: auto !important;
-  transform: none !important;
-}
-/* Ensure the chat toggle button is visible and positioned correctly */
+
+.vg-widget-controls-container,
 #vg_chat_toggle,
-button.vg-open-btn {
-  display: inline-flex !important;
-  visibility: visible !important;
-  opacity: 1 !important;
-  position: relative !important;
+.vg-widget-controls-container button {
   width: 64px !important;
   height: 64px !important;
-  z-index: 1000 !important;
+  min-width: 64px !important;
+  min-height: 64px !important;
+  max-width: 80px !important;
+  max-height: 80px !important;
 }
-/* Ensure modal opens 90% of screen and centered when modalMode is true */
-[data-vg-modal="true"],
+
+.vg-widget-controls-container {
+  position: fixed !important;
+  right: 20px !important;
+  bottom: 20px !important;
+  left: auto !important;
+  top: auto !important;
+  transform: none !important;
+}
+
 .vg-modal,
 .vg-modal-container,
-[class*="vg-modal"],
-div[class*="modal"] {
+[class*="vg-modal"] {
   position: fixed !important;
   top: 0 !important;
-  left: 0 !important;
   right: 0 !important;
   bottom: 0 !important;
+  left: 0 !important;
   width: 100vw !important;
   height: 100vh !important;
   margin: 0 !important;
   padding: 0 !important;
-  z-index: 999999 !important;
   display: flex !important;
   align-items: center !important;
   justify-content: center !important;
+  z-index: 999999 !important;
 }
-/* Ensure modal content is 90% of screen, centered, and responsive */
-[data-vg-modal="true"] > *,
+
 .vg-modal > *,
 .vg-modal-container > *,
-[data-vg-modal="true"] > * > *,
+[class*="vg-modal"] > *,
 .vg-modal > * > *,
-.vg-modal-container > * > * {
+.vg-modal-container > * > *,
+[class*="vg-modal"] > * > * {
   width: 90vw !important;
   height: 90vh !important;
   max-width: 90vw !important;
@@ -89,118 +66,36 @@ div[class*="modal"] {
   margin: auto !important;
   position: relative !important;
 }
-/* Mobile responsive - use 95% on small screens */
+
 @media (max-width: 768px) {
-  [data-vg-modal="true"] > *,
   .vg-modal > *,
   .vg-modal-container > *,
-  [data-vg-modal="true"] > * > *,
+  [class*="vg-modal"] > *,
   .vg-modal > * > *,
-  .vg-modal-container > * > * {
+  .vg-modal-container > * > *,
+  [class*="vg-modal"] > * > * {
     width: 95vw !important;
     height: 95vh !important;
     max-width: 95vw !important;
     max-height: 95vh !important;
   }
 }
-/* Fix tab navigation elements - prevent them from stretching too wide */
-/* Target navigation containers and tab panels */
-[class*="vg-nav"],
-[class*="nav"],
-[class*="tab"],
-[class*="sidebar"],
-[class*="menu"],
-div[class*="flex"][class*="items-center"] > div,
-div[class*="flex"][class*="justify"] > div {
-  max-width: 100% !important;
-  width: auto !important;
-  flex-shrink: 1 !important;
-  flex-grow: 0 !important;
-}
-/* Specifically target tab buttons/panels that might contain "Home", "Chats", "FAQ" */
-button[class*="vg-"],
-div[class*="vg-"][role="button"],
-div[class*="vg-"][role="tab"],
-button[class*="nav"],
-div[class*="nav"][role="button"] {
-  max-width: 200px !important;
-  width: auto !important;
-  min-width: unset !important;
-  flex-basis: auto !important;
-}
-/* Constrain any flex containers inside the modal */
-#VG_ROOT_INNER > * > *[class*="flex"],
-#VG_ROOT_INNER > *[class*="flex"] {
-  max-width: 100% !important;
+
+.vg-tabs,
+[class*="tabs"] {
   width: 100% !important;
+  max-width: 100% !important;
   overflow: hidden !important;
 }
-/* Ensure tab navigation doesn't exceed modal width */
-#VG_ROOT_INNER > * > *[class*="flex"] > *,
-#VG_ROOT_INNER > *[class*="flex"] > * {
-  max-width: 33.33% !important;
-  flex: 0 1 auto !important;
-  min-width: 0 !important;
-}
-/* Aggressively constrain tab navigation - target by text content */
-.vg-chat-overlay-container [class*="flex"] > *,
-#vg-mother-container [class*="flex"] > *,
-.vg-chat-view-container [class*="flex"] > * {
-  max-width: 120px !important;
-  flex: 0 1 auto !important;
-  min-width: 0 !important;
+
+.vg-tabs > *,
+[class*="tabs"] > *,
+.vg-tabs [role="tab"],
+[class*="tabs"] [role="tab"],
+.vg-tabs button,
+[class*="tabs"] button {
+  max-width: 160px !important;
   width: auto !important;
-}
-/* Target flex containers that likely contain tabs (2-5 children) */
-.vg-chat-overlay-container > * > [class*="flex"]:has(> *:nth-child(2)):has(> *:nth-child(3)),
-#vg-mother-container > * > [class*="flex"]:has(> *:nth-child(2)):has(> *:nth-child(3)) {
-  max-width: 100% !important;
-  width: 100% !important;
-  justify-content: flex-start !important;
-  gap: 8px !important;
-}
-/* Fix modal container sizing */
-.vg-chat-overlay-container {
-  width: 90vw !important;
-  max-width: 90vw !important;
-}
-#vg-mother-container {
-  width: 90vw !important;
-  max-width: 90vw !important;
-}
-@media (max-width: 768px) {
-  .vg-chat-overlay-container,
-  #vg-mother-container {
-    width: 95vw !important;
-    max-width: 95vw !important;
-  }
-}
-/* Ultra-aggressive tab fixing - target flex children in modal */
-.vg-chat-overlay-container button,
-.vg-chat-overlay-container [role="button"],
-.vg-chat-overlay-container [role="tab"],
-#vg-mother-container button,
-#vg-mother-container [role="button"],
-#vg-mother-container [role="tab"] {
-  max-width: 120px !important;
-  width: auto !important;
-  flex: 0 1 auto !important;
   min-width: 0 !important;
-}
-/* Target any flex container with 2-5 children (likely tab navigation) */
-.vg-chat-overlay-container > * > [class*="flex"]:nth-child(n+2):nth-child(-n+5),
-#vg-mother-container > * > [class*="flex"]:nth-child(n+2):nth-child(-n+5) {
-  justify-content: flex-start !important;
-  gap: 8px !important;
-  max-width: 100% !important;
-}
-/* Fix widget button aspect ratio */
-.vg-widget-controls-container,
-#vg_chat_toggle,
-button.vg-open-btn {
-  aspect-ratio: 1 !important;
-  min-width: 64px !important;
-  min-height: 64px !important;
-  max-width: 80px !important;
-  max-height: 80px !important;
+  flex: 0 1 auto !important;
 }


### PR DESCRIPTION
### Motivation
- Prevent CONVOCORE widget elements from stretching to viewport-sized overlays which broke page UI by hiding the proactive notification and constraining widget elements.
- Ensure the chat bubble toggle remains a compact button and modal content is centered and responsive to avoid black-screen overlays.
- Limit tab navigation items so tab buttons/panels do not expand beyond reasonable widths inside the modal.

### Description
- Add `public/convocore-overrides.css` which hides proactive notifications using high-specificity selectors like `.vg-proactive-notification--container`, `[class*="proactive-notification"]`, and `[class*="proactive"]` with `!important` rules preserved.
- Constrain the chat bubble and controls using `.vg-widget-controls-container`, `#vg_chat_toggle`, and `.vg-widget-controls-container button` to fixed compact sizes and fixed positioning.
- Force modal sizing and centering via `.vg-modal`, `.vg-modal-container`, and `[class*="vg-modal"]` and ensure modal children use `90vw`/`90vh` sizing with a mobile `@media` fallback to `95vw`/`95vh`.
- Constrain tabs using `.vg-tabs` and `[class*="tabs"]` and cap tab child widths to prevent overly wide tab items while keeping flexible layout behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971e41ea20083339134d4cf75711348)