### PR TITLE
Fix Convocore overlay container sizing to allow widget to mount

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
 
-    <div id="VG_OVERLAY_CONTAINER"></div>
+    <div id="VG_OVERLAY_CONTAINER" style="width: 0; height: 0;"></div>
     <script>
       (function() {
         window.VG_CONFIG = {


### PR DESCRIPTION
### Motivation
- Ensure the Convocore widget can mount and display its launch bubble by starting the overlay container hidden with zero width/height as required by the embed script.

### Description
- Add `style="width: 0; height: 0;"` to the `#VG_OVERLAY_CONTAINER` element in `index.html` so the Convocore script can attach the bubble correctly.

### Testing
- Served the built site with `python -m http.server 4173 --directory dist` and captured a page screenshot with Playwright which completed and produced `artifacts/convocore-bubble.png`, and the `convocore-overrides.css` file was present and served (HTTP 200).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971e0f849808333aaf4a14ad0ce855b)